### PR TITLE
publish to marketplace using Python 3.8

### DIFF
--- a/.github/workflows/publish-to-marketplace.yml
+++ b/.github/workflows/publish-to-marketplace.yml
@@ -12,7 +12,7 @@ jobs:
           node-version-file: '.tool-versions'
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.8"
       - run: pip install nox
       - run: nox --session setup
       - run: npm install --include=dev


### PR DESCRIPTION
For 3.8+ compatibility. We otherwise fail to bundle `importlib_metadata`, for example.

Thought that I had already done this, but apparently not.