### PR TITLE
ship for multiple platforms, fix `no module named regex._regex`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bundled/libs/
 **/.vs
 /venv*/
 .envrc
+/wheels/

--- a/package.json
+++ b/package.json
@@ -45,6 +45,9 @@
         "workspaceContains:*.py"
     ],
     "main": "./dist/extension.js",
+    "vsce": {
+        "baseImagesUrl": "https://raw.githubusercontent.com/bsilverthorn/maccarone-vscode/main/"
+    },
     "scripts": {
         "vscode:prepublish": "npm run package",
         "compile": "webpack",
@@ -56,7 +59,7 @@
         "lint": "eslint src --ext ts",
         "format-check": "prettier --check 'src/**/*.ts' 'build/**/*.yml' '.github/**/*.yml'",
         "test": "node ./out/test/runTest.js",
-        "vsce-package": "vsce package -o maccarone.vsix"
+        "vsce-package": "vsce package"
     },
     "contributes": {
         "configuration": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -195,9 +195,9 @@ charset-normalizer==3.2.0 \
     # via
     #   aiohttp
     #   requests
-exceptiongroup==1.1.2 \
-    --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5 \
-    --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f
+exceptiongroup==1.1.3 \
+    --hash=sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9 \
+    --hash=sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3
     # via cattrs
 frozenlist==1.4.0 \
     --hash=sha256:007df07a6e3eb3e33e9a1fe6a9db7af152bbd8a185f9aaa6ece10a3529e3e1c6 \

--- a/src/test/python_tests/requirements.txt
+++ b/src/test/python_tests/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --generate-hashes ./src/test/python_tests/requirements.in
 #
-exceptiongroup==1.1.2 \
-    --hash=sha256:12c3e887d6485d16943a309616de20ae5582633e0a2eda17f4e10fd61c1e8af5 \
-    --hash=sha256:e346e69d186172ca7cf029c8c1d16235aa0e04035e5750b4b95039e65204328f
+exceptiongroup==1.1.3 \
+    --hash=sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9 \
+    --hash=sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3
     # via pytest
 iniconfig==2.0.0 \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \


### PR DESCRIPTION
Right now we're shipping Python extension binaries that only work on (some) Linux systems. That's bad. To fix it, we need to start shipping a bunch of platform-specific binaries instead. =|

Much of this code is copied directly from

https://github.com/omnilib/vscode-ufmt/blob/b03cbef9e7b072f0b632dd2819e4481edc878133/noxfile.py

and related files. See also:

https://github.com/microsoft/vscode-python-tools-extension-template/issues/50