### PR TITLE
drop explicit eslint-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
                 "@types/node": "14.x",
                 "@types/vscode": "1.75.0",
                 "@typescript-eslint/eslint-plugin": "^6.4.1",
-                "@typescript-eslint/parser": "^5.62.0",
                 "@vscode/test-electron": "^2.3.3",
                 "@vscode/vsce": "^2.20.0",
                 "eslint": "^8.44.0",
@@ -440,104 +439,32 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
+            "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
             "dev": true,
+            "peer": true,
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/scope-manager": "6.4.1",
+                "@typescript-eslint/types": "6.4.1",
+                "@typescript-eslint/typescript-estree": "6.4.1",
+                "@typescript-eslint/visitor-keys": "6.4.1",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^16.0.0 || >=18.0.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+                "eslint": "^7.0.0 || ^8.0.0"
             },
             "peerDependenciesMeta": {
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-            "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-            "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-            "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/visitor-keys": "5.62.0",
-                "debug": "^4.3.4",
-                "globby": "^11.1.0",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.7",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-            "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.62.0",
-                "eslint-visitor-keys": "^3.3.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
@@ -4174,27 +4101,6 @@
                 "webpack": "^5.0.0"
             }
         },
-        "node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "node_modules/tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "dependencies": {
-                "tslib": "^1.8.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            },
-            "peerDependencies": {
-                "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-            }
-        },
         "node_modules/tunnel": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
@@ -5014,58 +4920,17 @@
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.62.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
-            "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.4.1.tgz",
+            "integrity": "sha512-610G6KHymg9V7EqOaNBMtD1GgpAmGROsmfHJPXNLCU9bfIuLrkdOygltK784F6Crboyd5tBFayPB7Sf0McrQwg==",
             "dev": true,
+            "peer": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.62.0",
-                "@typescript-eslint/types": "5.62.0",
-                "@typescript-eslint/typescript-estree": "5.62.0",
+                "@typescript-eslint/scope-manager": "6.4.1",
+                "@typescript-eslint/types": "6.4.1",
+                "@typescript-eslint/typescript-estree": "6.4.1",
+                "@typescript-eslint/visitor-keys": "6.4.1",
                 "debug": "^4.3.4"
-            },
-            "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "5.62.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
-                    "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.62.0",
-                        "@typescript-eslint/visitor-keys": "5.62.0"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "5.62.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
-                    "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
-                    "dev": true
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "5.62.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
-                    "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.62.0",
-                        "@typescript-eslint/visitor-keys": "5.62.0",
-                        "debug": "^4.3.4",
-                        "globby": "^11.1.0",
-                        "is-glob": "^4.0.3",
-                        "semver": "^7.3.7",
-                        "tsutils": "^3.21.0"
-                    }
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "5.62.0",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
-                    "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.62.0",
-                        "eslint-visitor-keys": "^3.3.0"
-                    }
-                }
             }
         },
         "@typescript-eslint/scope-manager": {
@@ -7784,21 +7649,6 @@
                 "enhanced-resolve": "^5.0.0",
                 "micromatch": "^4.0.0",
                 "semver": "^7.3.4"
-            }
-        },
-        "tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
-        "tsutils": {
-            "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
-            "dev": true,
-            "requires": {
-                "tslib": "^1.8.1"
             }
         },
         "tunnel": {

--- a/package.json
+++ b/package.json
@@ -175,7 +175,6 @@
         "@types/glob": "^8.1.0",
         "@types/node": "14.x",
         "@typescript-eslint/eslint-plugin": "^6.4.1",
-        "@typescript-eslint/parser": "^5.62.0",
         "@vscode/test-electron": "^2.3.3",
         "@vscode/vsce": "^2.20.0",
         "eslint": "^8.44.0",


### PR DESCRIPTION
It's already implicit from eslint-plugin. Making it explicit increases the risk of version conflict, for no obvious benefit.